### PR TITLE
Reduce fee payment from sender for burn

### DIFF
--- a/tinyman/v1/burn.py
+++ b/tinyman/v1/burn.py
@@ -16,7 +16,7 @@ def prepare_burn_transactions(validator_app_id, asset1_id, asset2_id, liquidity_
             sender=sender,
             sp=suggested_params,
             receiver=pool_address,
-            amt=4000,
+            amt=3000,
             note='fee',
         ),
         ApplicationNoOpTxn(


### PR DESCRIPTION
There are only 3 transactions being sent from the `POOLER_ADDRESS`.