### PR TITLE
Fixed issue with ASA name and unit-name

### DIFF
--- a/tinyman/assets.py
+++ b/tinyman/assets.py
@@ -24,7 +24,7 @@ class Asset:
                 'decimals': 6,
             }
         self.name = params.get('name', '')
-        self.unit_name = params['unit-name']
+        self.unit_name = params.get('unit-name', '')
         self.decimals = params['decimals']
         return self
 

--- a/tinyman/assets.py
+++ b/tinyman/assets.py
@@ -23,7 +23,7 @@ class Asset:
                 'unit-name': 'ALGO',
                 'decimals': 6,
             }
-        self.name = params['name']
+        self.name = params.get('name', '')
         self.unit_name = params['unit-name']
         self.decimals = params['decimals']
         return self


### PR DESCRIPTION
"name" and "unit-name" of an asset are both optional (recommended) parameters, as specified in the official Algorand documentation at https://developer.algorand.org/docs/get-details/asa/#asset-parameters

Issue can be reproduced by calling fetch_asset on any ASA with no name/unit-name.