### PR TITLE
Calculate Quote Price Factoring Asset Decimals

### DIFF
--- a/tinyman/v1/pools.py
+++ b/tinyman/v1/pools.py
@@ -1,4 +1,5 @@
 import math
+from decimal import Decimal
 from dataclasses import dataclass
 from base64 import b64encode, b64decode
 from algosdk.v2client.algod import AlgodClient
@@ -100,11 +101,26 @@ class SwapQuote:
 
     @property
     def price(self) -> float:
-        return self.amount_out.amount / self.amount_in.amount
+        return self.calculate_quote_price()
 
     @property
     def price_with_slippage(self) -> float:
-        return self.amount_out_with_slippage.amount / self.amount_in_with_slippage.amount
+        return self.calculate_quote_price(with_slippage=True)
+
+    def calculate_quote_price(self, with_slippage=True):
+        if with_slippage:
+            quote_amount_in = self.amount_in_with_slippage.amount
+            quote_amount_out = self.amount_out_with_slippage.amount
+        else:
+            quote_amount_in = self.amount_in.amount
+            quote_amount_out = self.amount_out.amount
+        amount_in = (
+            Decimal(quote_amount_in) 
+            / Decimal(10**self.amount_in.asset.decimals))
+        amount_out = (
+            Decimal(quote_amount_out) 
+            / Decimal(10**self.amount_out.asset.decimals))
+        return float(amount_out / amount_in)
 
 
 @dataclass


### PR DESCRIPTION
Hi,

At the moment, the quote price functions don't account for differences in decimals between asset in and asset out. This can cause an incorrect calculation of price if the assets have different decimals.

This PR converts amount in and amount out to Decimal, then adjusts for each asset's decimals before dividing both to calculate the price.

The following screenshot shows the incorrect price provided by the Quote class (_price_with_slippage_) and the correct price as per this PR's calculation (_quote_price_with_slippage_):
![algo_degen_quote_example](https://user-images.githubusercontent.com/1480671/147684584-580c5cca-33b5-4b26-b4e5-da61b32b3812.png)

Quote directly from Tinyman:
![algo_degen_website_quote](https://user-images.githubusercontent.com/1480671/147684723-3f9fbdb3-788f-46d5-85ed-434e18db5ff7.png)