### PR TITLE
Remove default algod client from TinymanClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ tinyman-py-sdk is not yet released on PYPI. It can be installed directly from th
 
 ```python
 from tinyman.v1.client import TinymanTestnetClient
+from algosdk.v2client.algod import AlgodClient
 
-client = TinymanTestnetClient()
+
+algod = AlgodClient('<TOKEN>', 'http://localhost:8080', headers={'User-Agent': 'algosdk'})
+client = TinymanTestnetClient(algod_client=algod)
 
 # Fetch our two assets of interest
 TINYUSDC = client.fetch_asset(21582668)

--- a/examples/add_liquidity1.py
+++ b/examples/add_liquidity1.py
@@ -3,6 +3,7 @@
 # This example does not constitute trading advice.
 
 from tinyman.v1.client import TinymanTestnetClient
+from algosdk.v2client.algod import AlgodClient
 
 
 # Hardcoding account keys is not a great practice. This is for demonstration purposes only.
@@ -12,7 +13,8 @@ account = {
     'private_key': 'base64_private_key_here', # Use algosdk.mnemonic.to_private_key(mnemonic) if necessary
 }
 
-client = TinymanTestnetClient(user_address=account['address'])
+algod = AlgodClient('<TOKEN>', 'http://localhost:8080', headers={'User-Agent': 'algosdk'})
+client = TinymanTestnetClient(algod_client=algod, user_address=account['address'])
 # By default all subsequent operations are on behalf of user_address
 
 # Fetch our two assets of interest

--- a/examples/pooling1.py
+++ b/examples/pooling1.py
@@ -3,6 +3,7 @@
 # This example does not constitute trading advice.
 
 from tinyman.v1.client import TinymanTestnetClient
+from algosdk.v2client.algod import AlgodClient
 
 
 # Hardcoding account keys is not a great practice. This is for demonstration purposes only.
@@ -12,7 +13,8 @@ account = {
     'private_key': 'base64_private_key_here', # Use algosdk.mnemonic.to_private_key(mnemonic) if necessary
 }
 
-client = TinymanTestnetClient(user_address=account['address'])
+algod = AlgodClient('<TOKEN>', 'http://localhost:8080', headers={'User-Agent': 'algosdk'})
+client = TinymanTestnetClient(algod_client=algod, user_address=account['address'])
 # By default all subsequent operations are on behalf of user_address
 
 # Fetch our two assets of interest

--- a/examples/swapping1.py
+++ b/examples/swapping1.py
@@ -5,6 +5,7 @@
 # For a more verbose version of this example see swapping1_less_convenience.py
 
 from tinyman.v1.client import TinymanTestnetClient
+from algosdk.v2client.algod import AlgodClient
 
 
 # Hardcoding account keys is not a great practice. This is for demonstration purposes only.
@@ -14,7 +15,8 @@ account = {
     'private_key': 'base64_private_key_here', # Use algosdk.mnemonic.to_private_key(mnemonic) if necessary
 }
 
-client = TinymanTestnetClient(user_address=account['address'])
+algod = AlgodClient('<TOKEN>', 'http://localhost:8080', headers={'User-Agent': 'algosdk'})
+client = TinymanTestnetClient(algod_client=algod, user_address=account['address'])
 # By default all subsequent operations are on behalf of user_address
 
 # Check if the account is opted into Tinyman and optin if necessary

--- a/examples/swapping1_less_convenience.py
+++ b/examples/swapping1_less_convenience.py
@@ -21,7 +21,7 @@ account = {
 }
 
 
-algod = AlgodClient('', 'https://api.testnet.algoexplorer.io', headers={'User-Agent': 'algosdk'})
+algod = AlgodClient('<TOKEN>', 'http://localhost:8080', headers={'User-Agent': 'algosdk'})
 
 client = TinymanClient(
     algod_client=algod,

--- a/tinyman/v1/client.py
+++ b/tinyman/v1/client.py
@@ -96,15 +96,10 @@ class TinymanClient:
 
 
 class TinymanTestnetClient(TinymanClient):
-    def __init__(self, algod_client=None, user_address=None):
-        if algod_client is None:
-            algod_client = AlgodClient('', 'https://api.testnet.algoexplorer.io', headers={'User-Agent': 'algosdk'})
+    def __init__(self, algod_client: AlgodClient, user_address=None):
         super().__init__(algod_client, validator_app_id=TESTNET_VALIDATOR_APP_ID, user_address=user_address)
 
 
 class TinymanMainnetClient(TinymanClient):
-    def __init__(self, algod_client=None, user_address=None):
-        if algod_client is None:
-            algod_client = AlgodClient('', 'https://api.algoexplorer.io', headers={'User-Agent': 'algosdk'})
+    def __init__(self, algod_client: AlgodClient, user_address=None):
         super().__init__(algod_client, validator_app_id=MAINNET_VALIDATOR_APP_ID, user_address=user_address)
-


### PR DESCRIPTION
We have decided to remove the default `AlgodClient` instance from the `TinymanTestnetClient` & `TinymanMainnetClient`. The user must now explicitly create an `AlgodClient` instance pointing to a node supporting the full version of the [Algod Rest API V2](https://developer.algorand.org/docs/rest-apis/algod/v2/).

There are two reasons for doing this:
* the default as currently set is using AlgoExplorer APIs that are now deprecated and will be disabled soon
* to avoid directing high levels of requests to public APIs by automated scripts using this sdk out of the box
