### PR TITLE
Bugfix for fetching assets without a unit name

### DIFF
--- a/tinyman/assets.py
+++ b/tinyman/assets.py
@@ -23,8 +23,8 @@ class Asset:
                 'unit-name': 'ALGO',
                 'decimals': 6,
             }
-        self.name = params['name']
-        self.unit_name = params['unit-name']
+        self.name = params.get('name', '')
+        self.unit_name = params.get('unit-name', '')
         self.decimals = params['decimals']
         return self
 


### PR DESCRIPTION
Algorand doesn't force that asset has to have a unit and/or unit name, so SDK raises KeyError for the assets [like this one](https://algoexplorer.io/asset/755517015).