### PR TITLE
Bugfix for fetching assets without a unit name

### DIFF
--- a/tinyman/assets.py
+++ b/tinyman/assets.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Optional
 
 @dataclass
 class Asset:
     id: int
-    name: str = None
-    unit_name: str = None
+    name: Optional[str] = None
+    unit_name: Optional[str] = None
     decimals: int = None
 
     def __call__(self, amount: int) -> "AssetAmount":
@@ -23,8 +24,8 @@ class Asset:
                 'unit-name': 'ALGO',
                 'decimals': 6,
             }
-        self.name = params.get('name', '')
-        self.unit_name = params.get('unit-name', '')
+        self.name = params.get('name')
+        self.unit_name = params.get('unit-name')
         self.decimals = params['decimals']
         return self
 


### PR DESCRIPTION
This is a follow-up PR according to the discussion in https://github.com/tinymanorg/tinyman-py-sdk/pull/37